### PR TITLE
Finalize result from invoke method with VariantClear

### DIFF
--- a/com.go
+++ b/com.go
@@ -18,6 +18,7 @@ var (
 	procGetUserDefaultLCID, _ = modkernel32.FindProc("GetUserDefaultLCID")
 	procCopyMemory, _         = modkernel32.FindProc("RtlMoveMemory")
 	procVariantInit, _        = modoleaut32.FindProc("VariantInit")
+	procVariantClear, _       = modoleaut32.FindProc("VariantClear")
 	procSysAllocString, _     = modoleaut32.FindProc("SysAllocString")
 	procSysFreeString, _      = modoleaut32.FindProc("SysFreeString")
 	procSysStringLen, _       = modoleaut32.FindProc("SysStringLen")
@@ -152,6 +153,14 @@ func GetActiveObject(clsid *GUID, iid *GUID) (unk *IUnknown, err error) {
 
 func VariantInit(v *VARIANT) (err error) {
 	hr, _, _ := procVariantInit.Call(uintptr(unsafe.Pointer(v)))
+	if hr != 0 {
+		err = NewError(hr)
+	}
+	return
+}
+
+func VariantClear(v *VARIANT) (err error) {
+	hr, _, _ := procVariantClear.Call(uintptr(unsafe.Pointer(v)))
 	if hr != 0 {
 		err = NewError(hr)
 	}

--- a/idispatch.go
+++ b/idispatch.go
@@ -1,6 +1,7 @@
 package ole
 
 import (
+	"runtime"
 	"syscall"
 	"unsafe"
 )
@@ -219,5 +220,8 @@ func invoke(disp *IDispatch, dispid int32, dispatch int16, params ...interface{}
 			}
 		*/
 	}
+
+	runtime.SetFinalizer(result, VariantClear)
+
 	return
 }

--- a/ole.go
+++ b/ole.go
@@ -89,6 +89,10 @@ func (v *VARIANT) ToString() string {
 	return UTF16PtrToString(*(**uint16)(unsafe.Pointer(&v.Val)))
 }
 
+func (v *VARIANT) Clear() error {
+	return VariantClear(v)
+}
+
 // Returns v's value based on its VALTYPE.
 // Currently supported types: 2- and 4-byte integers, strings, bools.
 // Note that 64-bit integers, datetimes, and other types are stored as strings


### PR DESCRIPTION
I had some serious leaks when invoking  ComVisible .NET methods that return string. After digging a bit deeper in this library I saw that the clean for the returned Variant is left to the user.

Adding a finalizer solved my leaks with the string, even though the doc for SetFinalizer states the following :  "so typically they are useful only for releasing non-memory resources associated with an object during a long-running program." http://golang.org/pkg/runtime/#SetFinalizer

Maybe another solution would be to expose VariantClear to the user and inform his that he has to call the method after he is finished with the return value.

Even if the user would cleanup the Variant it won't hurt to have the finalizer set (except some tiny CPU overhead).

Also, check out this article: https://github.com/felixge/go-cgo-finalizer. It looks like the go finalizer is would be of some help even for memory resources.

Please give me your thoughts. And do not merge it yet, I want to do some testing.
