### PR TITLE
Make go get compatible

### DIFF
--- a/com.go
+++ b/com.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/com_test.go
+++ b/com_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/connect.go
+++ b/connect.go
@@ -1,4 +1,7 @@
 // Helpers for COM
+//
+// +build windows
+
 package ole
 
 type Connection struct {

--- a/connect_test.go
+++ b/connect_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/constants.go
+++ b/constants.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 const (

--- a/go-get.go
+++ b/go-get.go
@@ -1,0 +1,6 @@
+// This file is here so go get succeeds, as without it errors with:
+// no buildable Go source files in ...
+//
+// +build !windows
+
+package oleutil

--- a/iconnectionpoint.go
+++ b/iconnectionpoint.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/iconnectionpointcontainer.go
+++ b/iconnectionpointcontainer.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/idispatch.go
+++ b/idispatch.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/iinspectable.go
+++ b/iinspectable.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/iprovideclassinfo.go
+++ b/iprovideclassinfo.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/itypeinfo.go
+++ b/itypeinfo.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/iunknown.go
+++ b/iunknown.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/ole.go
+++ b/ole.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/oleutil/go-get.go
+++ b/oleutil/go-get.go
@@ -1,0 +1,6 @@
+// This file is here so go get succeeds as without it errors with:
+// no buildable Go source files in ...
+//
+// +build !windows
+
+package oleutil

--- a/oleutil/oleutil.go
+++ b/oleutil/oleutil.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package oleutil
 
 import (

--- a/safearray.go
+++ b/safearray.go
@@ -1,4 +1,7 @@
 // Package is meant to retrieve and process safe array data returned from COM.
+//
+// +build windows
+
 package ole
 
 import (

--- a/safearray_test.go
+++ b/safearray_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/safearrayconversion.go
+++ b/safearrayconversion.go
@@ -1,4 +1,7 @@
 // Helper for converting SafeArray to array of objects.
+//
+// +build windows
+
 package ole
 
 import "unsafe"

--- a/safearrayconversion_test.go
+++ b/safearrayconversion_test.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/safearrayslices.go
+++ b/safearrayslices.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import "unsafe"

--- a/utility.go
+++ b/utility.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/variables.go
+++ b/variables.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (

--- a/variant.go
+++ b/variant.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import "unsafe"

--- a/variant_386.go
+++ b/variant_386.go
@@ -1,4 +1,6 @@
 // +build 386
+// +build windows
+
 package ole
 
 type VARIANT struct {

--- a/variant_amd64.go
+++ b/variant_amd64.go
@@ -1,4 +1,6 @@
 // +build amd64
+// +build windows
+
 package ole
 
 type VARIANT struct {

--- a/winrt.go
+++ b/winrt.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package ole
 
 import (


### PR DESCRIPTION
Added +build windows to all existing package source files.

Added go-get.go to base and oleutil directory which compiles for !windows so there is at least one file to compile.