### PR TITLE
Improve errors

### DIFF
--- a/idispatch.go
+++ b/idispatch.go
@@ -196,12 +196,7 @@ func invoke(disp *IDispatch, dispid int32, dispatch int16, params ...interface{}
 		uintptr(unsafe.Pointer(&excepInfo)),
 		0)
 	if hr != 0 {
-		if excepInfo.bstrDescription == nil {
-			err = NewError(hr)
-		} else {
-			bs := BstrToString(excepInfo.bstrDescription)
-			err = NewErrorWithDescription(hr, bs)
-		}
+		err = NewErrorWithSubError(hr, BstrToString(excepInfo.bstrDescription), excepInfo)
 	}
 	for _, varg := range vargs {
 		if varg.VT == VT_BSTR && varg.Val != 0 {

--- a/ole.go
+++ b/ole.go
@@ -2,6 +2,7 @@ package ole
 
 import (
 	"fmt"
+	"strings"
 	"syscall"
 	"unicode/utf16"
 )
@@ -9,6 +10,7 @@ import (
 type OleError struct {
 	hr          uintptr
 	description string
+	subError    error
 }
 
 func errstr(errno int) string {
@@ -26,11 +28,15 @@ func errstr(errno int) string {
 }
 
 func NewError(hr uintptr) *OleError {
-	return &OleError{hr, ""}
+	return &OleError{hr: hr}
 }
 
 func NewErrorWithDescription(hr uintptr, description string) *OleError {
-	return &OleError{hr, description}
+	return &OleError{hr: hr, description: description}
+}
+
+func NewErrorWithSubError(hr uintptr, description string, err error) *OleError {
+	return &OleError{hr: hr, description: description, subError: err}
 }
 
 func (v *OleError) Code() uintptr {
@@ -39,17 +45,21 @@ func (v *OleError) Code() uintptr {
 
 func (v *OleError) String() string {
 	if v.description != "" {
-		return errstr(int(v.hr)) + "(" + v.description + ")"
+		return errstr(int(v.hr)) + " (" + v.description + ")"
 	}
 	return errstr(int(v.hr))
 }
 
 func (v *OleError) Error() string {
-	return errstr(int(v.hr))
+	return v.String()
 }
 
 func (v *OleError) Description() string {
 	return v.description
+}
+
+func (v *OleError) SubError() error {
+	return v.subError
 }
 
 type DISPPARAMS struct {
@@ -68,7 +78,51 @@ type EXCEPINFO struct {
 	dwHelpContext     uint32
 	pvReserved        uintptr
 	pfnDeferredFillIn uintptr
-	scode             int32
+	scode             uint32
+}
+
+func (e EXCEPINFO) String() string {
+	var src, desc, hlp string
+	if e.bstrSource == nil {
+		src = "<nil>"
+	} else {
+		src = BstrToString(e.bstrSource)
+	}
+
+	if e.bstrDescription == nil {
+		desc = "<nil>"
+	} else {
+		desc = BstrToString(e.bstrDescription)
+	}
+
+	if e.bstrHelpFile == nil {
+		hlp = "<nil>"
+	} else {
+		hlp = BstrToString(e.bstrHelpFile)
+	}
+
+	return fmt.Sprintf(
+		"wCode: %#x, bstrSource: %v, bstrDescription: %v, bstrHelpFile: %v, dwHelpContext: %#x, scode: %#x",
+		e.wCode, src, desc, hlp, e.dwHelpContext, e.scode,
+	)
+}
+
+func (e EXCEPINFO) Error() string {
+	if e.bstrDescription != nil {
+		return strings.TrimSpace(BstrToString(e.bstrDescription))
+	}
+
+	src := "Unknown"
+	if e.bstrSource != nil {
+		src = BstrToString(e.bstrSource)
+	}
+
+	code := e.scode
+	if e.wCode != 0 {
+		code = uint32(e.wCode)
+	}
+
+	return fmt.Sprintf("%v: %#x", src, code)
 }
 
 type PARAMDATA struct {


### PR DESCRIPTION
Correct EXCEPINFO scode unit32 to match native Windows type.

Made EXCEPINFO support the Stringer and Error interfaces.

Added subError field and SubError() method to OleError which allows it to support capture of exception causes e.g. EXCEPINFO.

Added capture of EXCEPINFO error to invoke method. This provides consumers with visibility of the cause of exceptions.

Updated OleError.String() adding a space before description so errors read write e.g. "Exception occured. (Invalid Query)"

Made OleError.Error() use .String() so description is displayed if present. This makes exception errors actually display the cause instead of simply "Exception occured." which isn't helpful in determining the cause of the issue.